### PR TITLE
Match install_requires conditions to less strict versioning in requirements.txt; bump version number

### DIFF
--- a/hipsaint/__init__.py
+++ b/hipsaint/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (0, 4, 2, 'final', 0)
+VERSION = (0, 4, 3, 'final', 0)
 
 
 def get_version(version=None):

--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,8 @@ setup(
     test_suite='hipsaint.tests',
     tests_require=['mock'],
     install_requires=[
-        "Jinja2==2.6",
-        "requests==1.1.0"
+        "Jinja2>=2.6",
+        "requests>=1.1.0"
     ],
     entry_points="""
     [console_scripts]


### PR DESCRIPTION
This commit matches the setup.py install requirements to the requirements.txt file; see commit https://github.com/rtkjbillo/hipsaint/commit/2ce3aaf7c578cfdf32829fad7f13aaba36e9825d for the original change. This change was necessary to get hipsaint working when we had newer versions of both the requests and Jinja2 libraries installed already.

I realize there is an open issue to remove these dependencies entirely (https://github.com/hannseman/hipsaint/issues/9) but we've already made this modification to our local package, and figured others in the community could benefit from having things 'just work'.

If you accept this pull request, please also consider uploading it to the PyPI repository as well. Thanks!
