### PR TITLE
Add a "medium" template which is more informative than short but shorter than full

### DIFF
--- a/hipsaint/messages.py
+++ b/hipsaint/messages.py
@@ -109,9 +109,9 @@ class HipchatMessage(object):
         on the notification type.
         """
         template_type = self.type
-        if template_type in ('host', 'short-host'):
+        if 'host' in template_type:
             template_context = self.get_host_context()
-        elif template_type in ('service', 'short-service'):
+        elif 'service' in template_type:
             template_context = self.get_service_context()
         else:
             raise Exception('Invalid notification type')

--- a/hipsaint/templates.py
+++ b/hipsaint/templates.py
@@ -11,6 +11,7 @@ host_template = """
 <pre>{hostoutput}</pre>
 """
 
+host_medium_template = "<strong>{timestamp} - {hostname} ({hostaddress}) - {ntype}/{state}</strong><br/><pre>{hostoutput}</pre>"
 host_short_template = """[{ntype}] {hostname}: {hostoutput}"""
 
 service_template = """
@@ -22,8 +23,9 @@ service_template = """
 <pre>{serviceoutput}</pre>
 """
 
+service_medium_template = "<strong>{timestamp} - {servicedesc} on {hostalias} ({hostaddress}) - {ntype}/{state}</strong><br/><pre>{serviceoutput}</pre>"
 service_short_template = "[{ntype}] {hostalias} {servicedesc}: {serviceoutput}"
 
 
-templates = {'host': host_template, 'short-host': host_short_template,
-             'service': service_template, 'short-service': service_short_template}
+templates = {'host': host_template, 'medium-host': host_medium_template, 'short-host': host_short_template,
+             'service': service_template, 'medium-service': service_medium_template, 'short-service': service_short_template}


### PR DESCRIPTION
The full output takes up minimum 6 lines, often more, which fills up HipChat windows quickly.
The short output cuts out a lot of very useful information, notably "hostoutput" or "serviceoutput"

Medium has all metadata on one line, then the output