### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,15 +79,15 @@ Don't forget to fill ``<TOKEN>`` and ``<ROOM_ID>``.
 
 Hosts : /etc/icinga2/scripts/hipchat-host-notification.sh ::
     
-    #!/bin/sh
+    #!/bin/bash
     
-    hipsaint --user=Icinga --token=<TOKEN> --room=<ROOM_ID> --type=host --inputs="$HOSTNAME$|$LONGDATETIME$|$NOTIFICATIONTYPE$|$HOSTADDRESS$|$HOSTSTATE$|$HOSTOUTPUT$" -n
+    hipsaint --user=Icinga --token=<TOKEN> --room=<ROOM_ID> --type=host --inputs="$HOSTNAME|$LONGDATETIME|$NOTIFICATIONTYPE|$HOSTADDRESS|$HOSTSTATE|$HOSTOUTPUT" -n
 
 Services : /etc/icinga2/scripts/hipchat-service-notification.sh ::
 
-    #!/bin/sh
+    #!/bin/bash
 
-    hipsaint --user=Icinga --token=<TOKEN> --room=<ROOM_ID> --type=service --inputs="$SERVICEDESC$|$HOSTALIAS$|$LONGDATETIME$|$NOTIFICATIONTYPE$|$HOSTADDRESS$|$SERVICESTATE$|$SERVICEOUTPUT$" -n
+    hipsaint --user=Icinga --token=<TOKEN> --room=<ROOM_ID> --type=service --inputs="$SERVICEDESC|$HOSTALIAS|$LONGDATETIME|$NOTIFICATIONTYPE|$HOSTADDRESS|$SERVICESTATE|$SERVICEOUTPUT" -n
 
 Then you need to tell Icinga to use those scripts :
 


### PR DESCRIPTION
Removed trailing $s from the vars to be used in the bash script kicked off by icinga to send the message to hipchat.

For Icinga2, vars are passed to the script as normal environment vars - they don't use a trailing $ like nagios/icinga2 macros.