### PR TITLE
Highlight FLAPPINGEND in green instead of red

### DIFF
--- a/hipsaint/options.py
+++ b/hipsaint/options.py
@@ -6,6 +6,7 @@ COLORS = {
     'WARNING': 'yellow',
     'UNKNOWN': 'gray',
     'CRITICAL': 'red',
+    'FLAPPINGEND': 'green',
     'FLAPPINGSTOP': 'green',
     'FLAPPINGDISABLED': 'purple',
     'DOWNTIMESTART': 'red',


### PR DESCRIPTION
Icinga2 uses FLAPPINGEND instead of FLAPPINGSTOP