### PR TITLE
Enable notifications to room names with spaces

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Push your nagios notifications to HipChat using a simple command line tool.
 .. image:: https://travis-ci.org/hannseman/hipsaint.png?branch=master
   :target: https://travis-ci.org/hannseman/hipsaint
    
-.. image:: https://pypip.in/d/hipsaint/badge.png
+.. image:: https://img.shields.io/pypi/dm/hipsaint.svg
   :target: https://pypi.python.org/pypi/hipsaint
 
 Implements `HipChat message API`_.
@@ -41,11 +41,11 @@ Assuming you use Nagios 3 add the following sections to commands.cfg with ``<TOK
 
     define command {
         command_name    notify-host-by-hipchat
-        command_line    hipsaint --token=<TOKEN> --room=<ROOM_ID> --type=host --inputs="$HOSTNAME$|$LONGDATETIME$|$NOTIFICATIONTYPE$|$HOSTADDRESS$|$HOSTSTATE$|$HOSTOUTPUT$" -n
+        command_line    hipsaint -V 2 -token=<TOKEN> --room=<ROOM_ID> --type=host --inputs="$HOSTNAME$|$LONGDATETIME$|$NOTIFICATIONTYPE$|$HOSTADDRESS$|$HOSTSTATE$|$HOSTOUTPUT$" -n
     }
     define command {
         command_name    notify-service-by-hipchat
-        command_line    hipsaint --token=<TOKEN> --room=<ROOM_ID> --type=service --inputs="$SERVICEDESC$|$HOSTALIAS$|$LONGDATETIME$|$NOTIFICATIONTYPE$|$HOSTADDRESS$|$SERVICESTATE$|$SERVICEOUTPUT$" -n
+        command_line    hipsaint -V 2 --token=<TOKEN> --room=<ROOM_ID> --type=service --inputs="$SERVICEDESC$|$HOSTALIAS$|$LONGDATETIME$|$NOTIFICATIONTYPE$|$HOSTADDRESS$|$SERVICESTATE$|$SERVICEOUTPUT$" -n
     }
 
 To send less verbose messages to hipchat set the ``--type`` flag to either ``short-host`` or ``short-service``.

--- a/hipsaint/messages.py
+++ b/hipsaint/messages.py
@@ -5,6 +5,7 @@ try:
     from urllib.request import build_opener
     from urllib.request import install_opener
     from urllib.parse import urlencode
+    from urllib.parse import quote
 except ImportError:
     # Fall back to Python 2 urllib2
     from urllib2 import urlopen, Request
@@ -12,6 +13,7 @@ except ImportError:
     from urllib2 import build_opener
     from urllib2 import install_opener
     from urllib import urlencode
+    from urllib import quote
 import logging
 import socket
 import json
@@ -32,7 +34,9 @@ class HipchatMessage(object):
         self.inputs_list = [inp.strip() for inp in self.inputs.split('|')]
         self.token = token
         self.user = user
-        self.room_id = room_id
+        self.room_id = None
+        if room_id:
+            self.room_id = quote(room_id)
         self.notify = notify
         self.host = api_host or 'api.hipchat.com'
         self.api_version = api_version


### PR DESCRIPTION
Because the room name wasn't quoted (spaces weren't converted to %20)
the request resulted in a 400 Bad Request. This patches fixes that.

Also fixed the README, the examples use API v2 but don't include the -V
option, which is defaulted to v1. And the badge was broken.