### PR TITLE
[feature][card] Add API v2 Card type support

### DIFF
--- a/hipsaint/__init__.py
+++ b/hipsaint/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (0, 7, 0, 'final', 0)
+VERSION = (0, 7, 1, 'final', 0)
 
 
 def get_version(version=None):
@@ -22,5 +22,6 @@ def get_version(version=None):
         sub = mapping[version[3]] + str(version[4])
 
     return main + sub
+
 
 __version__ = get_version()

--- a/hipsaint/bin/commands.py
+++ b/hipsaint/bin/commands.py
@@ -63,9 +63,16 @@ def main():
                       dest="proxy",
                       help="Specify a proxy in the form [user:passwd@]proxy.server:port.")
 
-    ### Parse command line
+    parser.add_option("-c", "--card",
+                      action="store_true",
+                      default=False,
+                      dest="use_card",
+                      help="Wether or not use HipChat API v2 Card support or not. "
+                      "It requires using the V2 API.")
+
+    # Parse command line
     (options, args) = parser.parse_args()
-    ### Validate required input
+    # Validate required input
     if not options.token:
         parser.error('--token is required')
     if not options.inputs:

--- a/hipsaint/card.py
+++ b/hipsaint/card.py
@@ -1,6 +1,9 @@
 import uuid
+import logging
 from .options import STATE_STYLES, NOTIFICATION_STYLES
 
+logging.basicConfig()
+log = logging.getLogger(__name__)
 
 ICON_URL = 'http://i.imgur.com/BxqWsDC.png'
 
@@ -21,11 +24,9 @@ class Card(object):
         msg_body_len = len(self.hostoutput)
 
         if msg_body_len >= 500:
-            logging.warning('Host/Service ouput exceeds maximum allowed by V2 API: 500 ' \
-                + 'characters. Requested: ' + str(msg_body_len) \
-                + '. Truncating output to 500 total characters')
-            self.hostoutput = self.hostoutput[:487] + ' <truncated>"
-            
+            log.warning("Host/Service ouput exceeds maximum allowed by V2 API: 500")
+            self.hostoutput = self.hostoutput[:487] + ' <truncated>'
+
     def get_attributes(self):
         """
         More about Card attributes:

--- a/hipsaint/card.py
+++ b/hipsaint/card.py
@@ -16,6 +16,16 @@ class Card(object):
             self.service, self.hostalias, self.timestamp, self.ntype, self.hostaddress, self.state, self.hostoutput = [
                 inp.strip() for inp in self.inputs.split('|')]
 
+        # Ensure len of message body does not exceed limits
+        # https://www.hipchat.com/docs/apiv2/method/send_room_notification
+        msg_body_len = len(self.hostoutput)
+
+        if msg_body_len >= 500:
+            logging.warning('Host/Service ouput exceeds maximum allowed by V2 API: 500 ' \
+                + 'characters. Requested: ' + str(msg_body_len) \
+                + '. Truncating output to 500 total characters')
+            self.hostoutput = self.hostoutput[:487] + ' <truncated>"
+            
     def get_attributes(self):
         """
         More about Card attributes:

--- a/hipsaint/card.py
+++ b/hipsaint/card.py
@@ -1,0 +1,120 @@
+import uuid
+from .options import STATE_STYLES, NOTIFICATION_STYLES
+
+
+ICON_URL = 'http://i.imgur.com/BxqWsDC.png'
+
+
+class Card(object):
+    def __init__(self, inputs, handler_type):
+        self.inputs = inputs
+        self.handler_type = handler_type
+        if handler_type == 'host':
+            self.hostname, self.timestamp, self.ntype, self.hostaddress, self.state, self.hostoutput = [
+                inp.strip() for inp in self.inputs.split('|')]
+        else:
+            self.service, self.hostalias, self.timestamp, self.ntype, self.hostaddress, self.state, self.hostoutput = [
+                inp.strip() for inp in self.inputs.split('|')]
+
+    def get_style_old(self):
+        """
+        Style mapping for the supported atlassian lozenge styles.
+        For more see: https://docs.atlassian.com/aui/latest/docs/lozenges.html
+        """
+        state_mapping = {
+            'CRITICAL': 'lozenge-error',
+            'WARNING': 'lozenge-current',
+            'OK': 'lozenge-success',
+            'UNKNOWN': 'lozenge',
+            'DOWN': 'lozenge-error',
+            'UP': 'lozenge-success',
+            'UNREACHABLE': 'lozenge-error'
+        }
+
+        if self.state not in state_mapping:
+            return 'lozenge'
+        else:
+            return state_mapping[self.state]
+
+    def get_attributes(self):
+        """
+        More about Card attributes:
+        https://developer.atlassian.com/hipchat/guide/sending-messages
+        """
+        attributes = [
+            {
+                'value': {
+                    'label': self.ntype
+                },
+                'label': 'Type'
+            },
+            {
+                'value': {
+                    'label': self.state,
+                    'style': STATE_STYLES.get(self.state, 'lozenge')
+                },
+                'label': 'State'
+            },
+            {
+                'value': {
+                    'label': '%s (%s)' % (self.hostname if self.handler_type == 'host' else
+                                          self.hostalias, self.hostaddress)
+                },
+                'label': 'Host'
+            }]
+        return attributes
+
+    def get_activity(self):
+        """
+        More about Card activity:
+        https://developer.atlassian.com/hipchat/guide/sending-messages
+        """
+        if self.handler_type == 'host':
+            activity = {
+                'html': '<b>%(hostname)s</b> (%(hostaddress)s) - <span class="aui-lozenge aui-%(style)s">%(ntype)s</span>' % {
+                    'hostname': self.hostname,
+                    'hostaddress': self.hostaddress,
+                    'style': NOTIFICATION_STYLES.get(self.ntype, "lozenge"),
+                    'ntype': self.ntype},
+                'icon': ICON_URL
+            }
+        else:
+            activity = {
+                'html': '<b>%(service)s</b> on %(hostalias)s (%(hostaddress)s) - <span class="aui-lozenge aui-%(style)s">%(ntype)s</span>' % {
+                    'hostalias': self.hostalias,
+                    'service': self.service,
+                    'hostaddress': self.hostaddress,
+                    'style': NOTIFICATION_STYLES.get(self.ntype, "lozenge"),
+                    'ntype': self.ntype},
+                'icon': ICON_URL}
+        return activity
+
+    def get_card(self):
+        card_object = {
+            'id': str(uuid.uuid4()),
+            'icon': ICON_URL,
+            'style': 'application',
+            'format': 'medium',
+            'title': '',
+            'description': self.hostoutput,
+            # The box content comes from here:
+            'activity': self.get_activity(),
+            'attributes': self.get_attributes()
+        }
+        if self.handler_type == 'host':
+            card_object['title'] = '%(ntype)s - %(hostname)s (%(hostaddress)s) is %(state)s' % {
+                    'ntype': self.ntype,
+                    'hostname': self.hostname,
+                    'hostaddress': self.hostaddress,
+                    'state': self.state
+                }
+        else:
+            card_object['title'] = '%(ntype)s - %(service)s on %(hostalias)s (%(hostaddress)s) is %(state)s' % {
+                    'ntype': self.ntype,
+                    'service': self.service,
+                    'hostalias': self.hostalias,
+                    'hostaddress': self.hostaddress,
+                    'state': self.state
+                }
+
+        return card_object

--- a/hipsaint/card.py
+++ b/hipsaint/card.py
@@ -16,26 +16,6 @@ class Card(object):
             self.service, self.hostalias, self.timestamp, self.ntype, self.hostaddress, self.state, self.hostoutput = [
                 inp.strip() for inp in self.inputs.split('|')]
 
-    def get_style_old(self):
-        """
-        Style mapping for the supported atlassian lozenge styles.
-        For more see: https://docs.atlassian.com/aui/latest/docs/lozenges.html
-        """
-        state_mapping = {
-            'CRITICAL': 'lozenge-error',
-            'WARNING': 'lozenge-current',
-            'OK': 'lozenge-success',
-            'UNKNOWN': 'lozenge',
-            'DOWN': 'lozenge-error',
-            'UP': 'lozenge-success',
-            'UNREACHABLE': 'lozenge-error'
-        }
-
-        if self.state not in state_mapping:
-            return 'lozenge'
-        else:
-            return state_mapping[self.state]
-
     def get_attributes(self):
         """
         More about Card attributes:

--- a/hipsaint/options.py
+++ b/hipsaint/options.py
@@ -14,3 +14,32 @@ COLORS = {
     'DOWNTIMESTOP': 'green',
     'DOWNTIMEEND': 'green'
 }
+
+
+STATE_STYLES = {
+    'CRITICAL': 'lozenge-error',
+    'WARNING': 'lozenge-current',
+    'OK': 'lozenge-success',
+    'UNKNOWN': 'lozenge',
+    'DOWN': 'lozenge-error',
+    'UP': 'lozenge-success',
+    'UNREACHABLE': 'lozenge-error'
+}
+
+
+NOTIFICATION_STYLES = {
+    'PROBLEM': 'lozenge-error',
+    'RECOVERY': 'lozenge-success',
+    'UP': 'lozenge-success',
+    'ACKNOWLEDGEMENT': 'lozenge',
+    'FLAPPINGSTART': 'lozenge-current',
+    'WARNING': 'lozenge-current',
+    'UNKNOWN': 'lozenge',
+    'CRITICAL': 'lozenge-error',
+    'FLAPPINGEND': 'lozenge-success',
+    'FLAPPINGSTOP': 'lozenge-success',
+    'FLAPPINGDISABLED': 'lozenge',
+    'DOWNTIMESTART': 'lozenge-error',
+    'DOWNTIMESTOP': 'lozenge-success',
+    'DOWNTIMEEND': 'lozenge-success'
+}


### PR DESCRIPTION
I love the new v2 API supported card type messages.

For now the messages would look like these below.

Feel free to test it and let me know if you like it. I think this card type can merge the short and extended notification, since you can check the details by expanding the message. We just need to define what details should go on the collapsed line and what details on the expanded box.

Any comments are welcome.

## all collapsed by default
![all](http://i.imgur.com/WjQVYT6.png)

## services expanded
![services expanded](http://i.imgur.com/ay0ZX5S.png)

## hosts expanded
![hosts expanded](http://i.imgur.com/umbNOdE.png)